### PR TITLE
docs: Added 0103AL233146.txt in contributors

### DIFF
--- a/contributors/0103AL231146.txt
+++ b/contributors/0103AL231146.txt
@@ -1,0 +1,4 @@
+Name: Prashant kumar dwivedi
+GitHub Username: dwiivediprashant
+Your hobbies: Playing chess
+Write some thing that you expect from this event: I expect the title of winner 😄


### PR DESCRIPTION
Issue: #1 
 - Added self details in contributors folder


<img width="1119" height="423" alt="image" src="https://github.com/user-attachments/assets/75f3fc82-38b3-401b-bd63-bd02ab51ec08" />
