### PR TITLE
fix: integrate history with backend and store verdicts (Issue #153)

### DIFF
--- a/client/cyber_lens/package-lock.json
+++ b/client/cyber_lens/package-lock.json
@@ -2369,7 +2369,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }

--- a/client/cyber_lens/src/pages/History.tsx
+++ b/client/cyber_lens/src/pages/History.tsx
@@ -1,3 +1,6 @@
+import { useEffect, useState } from "react";
+import { httpJson } from "../utils/httpClient";
+
 type Row = {
   ioc: string;
   verdict: "Malicious" | "Clean" | "Suspicious" | "";
@@ -5,27 +8,44 @@ type Row = {
   note: string;
 };
 
+interface HistoryItem {
+  id: string;
+  owner_type: string;
+  owner_id: string;
+  ioc_type: string;
+  ioc_value: string;
+  verdict: string;
+  created_at: string;
+}
+
 export default function History() {
-  const dummyData: Row[] = [
-    {
-      ioc: "8.8.8.8",
-      verdict: "Malicious",
-      timestamp: "2025-01-12 14:32",
-      note: "Known public DNS abuse",
-    },
-    {
-      ioc: "example.com",
-      verdict: "Clean",
-      timestamp: "2025-01-11 10:05",
-      note: "No recent issues",
-    },
-    {
-      ioc: "http://suspicious.example",
-      verdict: "Suspicious",
-      timestamp: "2025-01-10 08:14",
-      note: "Low-confidence detection",
-    },
-  ];
+  const [data, setData] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    httpJson<HistoryItem[]>("/history?limit=50")
+      .then((items) => {
+        const rows: Row[] = items.map((item) => {
+          let verdict: Row["verdict"] = "";
+          const v = item.verdict?.toLowerCase() || "";
+          if (v === "malicious") verdict = "Malicious";
+          else if (v === "benign") verdict = "Clean";
+          else if (v === "suspicious") verdict = "Suspicious";
+
+          return {
+            ioc: item.ioc_value,
+            verdict,
+            timestamp: new Date(item.created_at).toLocaleString(),
+            note: item.ioc_type,
+          };
+        });
+        setData(rows);
+      })
+      .catch((err) => {
+        console.error("Failed to fetch history:", err);
+      })
+      .finally(() => setLoading(false));
+  }, []);
 
   const badgeClass = (v: string) =>
     v === "Malicious"
@@ -64,105 +84,78 @@ export default function History() {
           </div>
         </div>
 
-        {/* Mobile cards */}
-        <div className="space-y-4 md:hidden">
-          {dummyData.map((row, idx) => (
-            <div
-              key={idx}
-              className="border border-neutral-800 bg-neutral-900 p-4"
-            >
-              <div className="flex justify-between items-start gap-3">
-                <div className="font-mono text-sm text-neutral-100 truncate">
-                  {row.ioc}
-                </div>
-                <span
-                  className={`px-2 py-0.5 text-xs font-medium ring-1 ${badgeClass(
-                    row.verdict
-                  )}`}
+        {loading ? (
+          <div className="text-center text-neutral-500">Loading history...</div>
+        ) : (
+          <>
+            {/* Mobile cards */}
+            <div className="space-y-4 md:hidden">
+              {data.map((row, idx) => (
+                <div
+                  key={idx}
+                  className="border border-neutral-800 bg-neutral-900 p-4"
                 >
-                  {row.verdict || "Unknown"}
-                </span>
-              </div>
+                  <div className="flex justify-between items-start gap-3">
+                    <div className="font-mono text-sm text-neutral-100 truncate">
+                      {row.ioc}
+                    </div>
+                    <span
+                      className={`px-2 py-0.5 text-xs font-medium ring-1 ${badgeClass(
+                        row.verdict
+                      )}`}
+                    >
+                      {row.verdict || "Unknown"}
+                    </span>
+                  </div>
 
-              <div className="mt-2 text-sm text-neutral-300">{row.note}</div>
+                  <div className="mt-2 text-sm text-neutral-300">{row.note}</div>
 
-              <div className="mt-3 text-xs text-neutral-400">
-                {row.timestamp}
+                  <div className="mt-3 text-xs text-neutral-400">
+                    {row.timestamp}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Desktop Table */}
+            <div className="hidden md:block">
+              <div className="overflow-x-auto border border-neutral-700 bg-neutral-950">
+                <table className="min-w-full border-collapse text-sm">
+                  <thead className="bg-neutral-900 text-neutral-300">
+                    <tr>
+                      <th className="px-4 py-3 text-left font-medium">IOC</th>
+                      <th className="px-4 py-3 text-left font-medium">Verdict</th>
+                      <th className="px-4 py-3 text-left font-medium">Type</th>
+                      <th className="px-4 py-3 text-right font-medium">Time</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-neutral-800">
+                    {data.map((row, idx) => (
+                      <tr key={idx} className="hover:bg-neutral-900/50">
+                        <td className="px-4 py-3 font-mono text-neutral-200">
+                          {row.ioc}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span
+                            className={`px-2 py-0.5 text-xs font-medium ring-1 ${badgeClass(
+                              row.verdict
+                            )}`}
+                          >
+                            {row.verdict || "Unknown"}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-neutral-400">{row.note}</td>
+                        <td className="px-4 py-3 text-right text-neutral-500">
+                          {row.timestamp}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             </div>
-          ))}
-        </div>
-
-        {/* Desktop Table */}
-        <div className="hidden md:block">
-          <div className="overflow-x-auto border border-neutral-700 bg-neutral-950">
-            <table className="min-w-full border-collapse text-sm">
-              <thead className="bg-neutral-900 text-neutral-300">
-                <tr>
-                  <th className="border border-neutral-700 px-4 py-3 text-left font-medium">
-                    IOC
-                  </th>
-                  <th className="border border-neutral-700 px-4 py-3 text-left font-medium">
-                    Verdict
-                  </th>
-                  <th className="border border-neutral-700 px-4 py-3 text-left font-medium">
-                    Timestamp
-                  </th>
-                  <th className="border border-neutral-700 px-4 py-3 text-left font-medium">
-                    Note
-                  </th>
-                </tr>
-              </thead>
-
-              <tbody>
-                {dummyData.map((row, idx) => (
-                  <tr
-                    key={idx}
-                    className="hover:bg-neutral-900 transition-colors"
-                  >
-                    <td className="border border-neutral-800 px-4 py-3 font-mono text-neutral-100 truncate max-w-lg">
-                      {row.ioc || "—"}
-                    </td>
-
-                    <td className="border border-neutral-800 px-4 py-3">
-                      <span
-                        className={`inline-flex items-center gap-2 px-2.5 py-1 text-xs font-medium ring-1 ${badgeClass(
-                          row.verdict
-                        )}`}
-                      >
-                        <span
-                          className={`h-2 w-2 rounded-full ${
-                            row.verdict === "Malicious"
-                              ? "bg-red-400"
-                              : row.verdict === "Clean"
-                              ? "bg-emerald-400"
-                              : row.verdict === "Suspicious"
-                              ? "bg-amber-400"
-                              : "bg-neutral-400"
-                          }`}
-                        />
-                        {row.verdict || "Unknown"}
-                      </span>
-                    </td>
-
-                    <td className="border border-neutral-800 px-4 py-3 text-neutral-400 whitespace-nowrap">
-                      {row.timestamp || "—"}
-                    </td>
-
-                    <td className="border border-neutral-800 px-4 py-3 text-neutral-300 truncate max-w-xs">
-                      {row.note || "—"}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="mt-3 text-xs text-neutral-500">
-            Showing {dummyData.length} recent scans — optimized for analyst
-            review.
-          </div>
-        </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,7 +8,8 @@
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "pg": "^8.17.1"
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -170,6 +171,7 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1126,28 +1128,75 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pg": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.1.tgz",
+      "integrity": "sha512-EIR+jXdYNSMOrpRp7g6WgQr7SaZNZfS7IzZIO0oTNEeibq956JxeD15t3Jk3zZH0KH8DmOIx38qJfQenoE8bXQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.10.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.10.0.tgz",
+      "integrity": "sha512-ur/eoPKzDx2IjPaYyXS6Y8NSblxM7X64deV2ObV57vhjsWiwLvUD6meukAzogiOsu60GO8m/3Cb6FdJsWNjwXg==",
+      "license": "MIT"
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-pool": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
     "node_modules/pg-protocol": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
-      "dev": true,
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -1158,6 +1207,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picomatch": {
@@ -1177,7 +1235,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -1187,7 +1244,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1197,7 +1253,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1207,7 +1262,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -1459,6 +1513,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1634,7 +1697,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "pg": "^8.17.1"
   }
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import resolveOwner from "./utils/resolveOwner";
 import lookupRouter from "./routes/lookup";
+import historyRouter from "./routes/index";
 
 const app = express();
 
@@ -13,6 +14,7 @@ app.use(resolveOwner);
 // Simple health route
 app.get("/", (_req, res) => res.json({ status: "ok" }));
 
-app.use("/lookup", lookupRouter);
+app.use("/api/lookup", lookupRouter);
+app.use("/api", historyRouter);
 
 export default app;

--- a/server/src/routes/lookup.ts
+++ b/server/src/routes/lookup.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { orchestrateThreatIntelligence } from "../services/iocOrchestrator";
 import { computeScore } from "../services/scoringEngine";
+import { logIocHistory } from "../services/iocHistoryService";
 import { ALL_PROVIDERS } from "../services/providerExecutor";
 import type { IocType } from "../constants/provider.interface";
 
@@ -30,6 +31,17 @@ router.post("/", async (req, res) => {
     const scoringResult = computeScore({
       providers: orchestratedResult.providers,
     });
+
+    if (orchestratedResult.detectedType) {
+      void logIocHistory({
+        owner,
+        iocType: orchestratedResult.detectedType,
+        iocValue: ioc,
+        verdict: scoringResult.verdict,
+      }).catch(() => {
+        // intentionally ignored
+      });
+    }
 
     const response = {
       ioc: orchestratedResult.ioc,

--- a/server/src/services/iocHistoryQueryService.ts
+++ b/server/src/services/iocHistoryQueryService.ts
@@ -21,6 +21,7 @@ export async function queryHistory({
       owner_id,
       ioc_type,
       ioc_value,
+      verdict,
       created_at
     FROM ioc_history
     WHERE owner_type = $1

--- a/server/src/services/iocHistoryService.ts
+++ b/server/src/services/iocHistoryService.ts
@@ -6,19 +6,21 @@ interface LogIocHistoryParams {
   owner: OwnerContext;
   iocType: IocType;
   iocValue: string;
+  verdict?: string;
 }
 
 export async function logIocHistory({
   owner,
   iocType,
   iocValue,
+  verdict,
 }: LogIocHistoryParams): Promise<void> {
   await pool.query(
     `
-    INSERT INTO ioc_history (owner_type, owner_id, ioc_type, ioc_value)
-    VALUES ($1, $2, $3, $4)
+    INSERT INTO ioc_history (owner_type, owner_id, ioc_type, ioc_value, verdict)
+    VALUES ($1, $2, $3, $4, $5)
     `,
-    [owner.type, owner.id, iocType, iocValue]
+    [owner.type, owner.id, iocType, iocValue, verdict]
   );
 }
   

--- a/server/src/services/iocOrchestrator.ts
+++ b/server/src/services/iocOrchestrator.ts
@@ -8,7 +8,6 @@ import type {
   ThreatIntelProvider,
 } from "../constants/provider.interface";
 import type { OwnerContext } from "../constants/owner";
-import { logIocHistory } from "./iocHistoryService";
 
 export interface OrchestratedResponse<TResponse = unknown> {
   ioc: string;
@@ -83,15 +82,6 @@ export async function orchestrateThreatIntelligence<
   );
 
   const executionTimeMs = Date.now() - startTime;
-
-  // Fire-and-forget history logging (NON-BLOCKING)
-  void logIocHistory({
-    owner,
-    iocType: detected.type,
-    iocValue: ioc,
-  }).catch(() => {
-    // intentionally ignored
-  });
 
   // Return lookup response normally
   return {


### PR DESCRIPTION
Issue : #153

This PR fixes Issue #153 by implementing backend history storage with verdicts and connecting the frontend History page.

## Changes
- **Backend**:
  - Added 'pg' dependency to fix runtime crash.
  - Updated database logic to include 'verdict' in 'ioc_history' table.
  - Fixed logic bug: IOC history is now logged *after* the verdict is computed in 'scoringEngine'.
  - Mounted history routes in 'app.ts'.
- **Frontend**:
  - Connected 'History.tsx' to '/api/history' to display real scan data.
  - Replaced dummy data with API response mapping.

## Verification
- Verified server starts without crashing.
- Verified scan history is correctly stored in DB with verdicts (Malicious/Clean/Suspicious).
- Verified History page displays the correct data from the backend.