### PR TITLE
Added Different registeration & reset password email template

### DIFF
--- a/server/src/controllers/authPasswordResetController.ts
+++ b/server/src/controllers/authPasswordResetController.ts
@@ -34,6 +34,7 @@ export async function requestPasswordResetController(
       to: email,
       subject: "Reset your Cyber Lens password",
       verificationLink: resetLink,
+      emailType: "passwordReset",
     });
   }
   return res.json({

--- a/server/src/services/emailService.ts
+++ b/server/src/services/emailService.ts
@@ -5,18 +5,62 @@ interface SendEmailOptions {
   to: string;
   subject: string;
   verificationLink: string;
+  emailType?: 'registration' | 'passwordReset';
 }
 
 export async function sendEmail({
   to,
   subject,
   verificationLink,
+  emailType = 'registration',
 }: SendEmailOptions): Promise<void> {
   try {
-    const info = await transporter.sendMail({
-      from: process.env.SMTP_FROM,
-      to,
-      subject,
+    const isPasswordReset = emailType === 'passwordReset';
+    
+    const emailContent = isPasswordReset ? {
+      text: `
+        Reset your Cyber Lens password
+
+        You requested to reset your password. Click the link below to set a new password:
+        ${verificationLink}
+
+        This link will expire in 1 hour. If you didn't request this password reset, you can safely ignore this email.
+        `,
+      html: `
+        <div style="font-family: Arial, Helvetica, sans-serif; line-height: 1.6; color: #111;">
+          <h2 style="margin-bottom: 12px;">Reset your Cyber Lens password</h2>
+
+          <p>
+            You requested to reset your password. Click the link below to set a new password:
+          </p>
+
+          <p>
+            <a
+              href="${verificationLink}"
+              style="
+                color: #2563eb;
+                text-decoration: none;
+                font-weight: 500;
+              "
+            >
+              Click here to reset your password
+            </a>
+          </p>
+
+          <p style="margin-top: 16px; color: #666;">
+            <strong>Note:</strong> This link will expire in 1 hour for security reasons.
+          </p>
+
+          <p style="margin-top: 16px;">
+            If you didn't request this password reset, you can safely ignore this email.
+          </p>
+
+          <p style="margin-top: 24px; color: #555;">
+            - Cyber Lens Team
+          </p>
+        </div>
+      `
+    } : {
       text: `
         Welcome to Cyber Lens!
 
@@ -55,7 +99,15 @@ export async function sendEmail({
             - Cyber Lens Team
           </p>
         </div>
-      `,
+      `
+    };
+
+    const info = await transporter.sendMail({
+      from: process.env.SMTP_FROM,
+      to,
+      subject,
+      text: emailContent.text,
+      html: emailContent.html,
     });
 
     // Ethereal/stream preview URL (for testing)


### PR DESCRIPTION
Issue : #258 

---

## registeration email

<img width="593" height="303" alt="Screenshot 2026-01-29 002616" src="https://github.com/user-attachments/assets/7cd13eff-2a6c-4940-93be-891f029291f3" />


## reset email

<img width="611" height="373" alt="Screenshot 2026-01-29 002652" src="https://github.com/user-attachments/assets/d68ae0cb-a9d9-4623-a18b-92aa984c76c9" />
